### PR TITLE
Compile & run 5.4.0

### DIFF
--- a/sample/tcp/Makefile
+++ b/sample/tcp/Makefile
@@ -25,8 +25,11 @@ ifeq ($(ADDRSAFE),true)
 	EXTRA_CFLAGS += -DKSOCKET_ADDR_SAFE
 endif
 
-default:
+default: symvers
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+symvers:
+	cp ../../src/Module.symvers . || false
 
 clean:
 	rm -rf *.ko *.o *.mod.* .H* .tm* .*cmd Module.symvers modules.order

--- a/sample/tcp/ksocket.h
+++ b/sample/tcp/ksocket.h
@@ -1,6 +1,6 @@
 /* 
  * ksocket project
- * BSD-style socket APIs for kernel 2.6 developers
+ * BSD-style socket APIs for kernel 5.0 developers
  * 
  * @2007-2008, China
  * @song.xian-guang@hotmail.com (MSN Accounts)

--- a/sample/tcp/ksocket_tcp_cli_demo.c
+++ b/sample/tcp/ksocket_tcp_cli_demo.c
@@ -25,13 +25,12 @@
 
 #include "ksocket.h"
 
-#define BUF_SIZE 100
 
 int tcp_cli(void *arg)
 {
 	ksocket_t sockfd_cli;
 	struct sockaddr_in addr_srv;
-	char buf[BUF_SIZE], *tmp;
+	char buf[128] = {0}, *tmp;
 	int addr_len;
 
 #ifdef KSOCKET_ADDR_SAFE

--- a/sample/tcp/ksocket_tcp_cli_demo.c
+++ b/sample/tcp/ksocket_tcp_cli_demo.c
@@ -1,6 +1,6 @@
 /* 
  * ksocket project test sample - tcp client
- * BSD-style socket APIs for kernel 2.6 developers
+ * BSD-style socket APIs for kernel 5.0 developers
  * 
  * @2007-2008, China
  * @song.xian-guang@hotmail.com (MSN Accounts)

--- a/sample/tcp/ksocket_tcp_cli_demo.c
+++ b/sample/tcp/ksocket_tcp_cli_demo.c
@@ -63,6 +63,7 @@ int tcp_cli(void *arg)
 	
 	krecv(sockfd_cli, buf, 1024, 0);
 	ksend(sockfd_cli, tmp, 4, 0);
+	buf[strcspn(buf, "\r\n")] = 0;
 	printk("got message : %s\n", buf);
 
 	kclose(sockfd_cli);

--- a/sample/tcp/ksocket_tcp_srv_demo.c
+++ b/sample/tcp/ksocket_tcp_srv_demo.c
@@ -1,6 +1,6 @@
 /* 
  * ksocket project test sample - tcp server
- * BSD-style socket APIs for kernel 2.6 developers
+ * BSD-style socket APIs for kernel 5.0 developers
  * 
  * @2007-2008, China
  * @song.xian-guang@hotmail.com (MSN Accounts)

--- a/sample/tcp/ksocket_tcp_srv_demo.c
+++ b/sample/tcp/ksocket_tcp_srv_demo.c
@@ -93,6 +93,7 @@ int tcp_srv(void *arg)
 		len = krecv(sockfd_cli, buf, sizeof(buf), 0);
 		if (len > 0)
 		{
+			buf[strcspn(buf, "\r\n")] = 0;
 			printk("got message : %s\n", buf);
 			ksend(sockfd_cli, buf, len, 0);
 			if (memcmp(buf, "quit", 4) == 0)

--- a/sample/udp/Makefile
+++ b/sample/udp/Makefile
@@ -25,8 +25,11 @@ ifeq ($(ADDRSAFE),true)
 	EXTRA_CFLAGS += -DKSOCKET_ADDR_SAFE
 endif
 
-default:
+default: symvers
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
+
+symvers:
+	cp ../../src/Module.symvers . || false
 
 clean:
 	rm -rf *.ko *.o *.mod.* .H* .tm* .*cmd Module.symvers modules.order

--- a/sample/udp/ksocket.h
+++ b/sample/udp/ksocket.h
@@ -1,6 +1,6 @@
 /* 
  * ksocket project
- * BSD-style socket APIs for kernel 2.6 developers
+ * BSD-style socket APIs for kernel 5.0 developers
  * 
  * @2007-2008, China
  * @song.xian-guang@hotmail.com (MSN Accounts)

--- a/sample/udp/ksocket_udp_cli_demo.c
+++ b/sample/udp/ksocket_udp_cli_demo.c
@@ -1,6 +1,6 @@
 /* 
  * ksocket project test sample - udp client
- * BSD-style socket APIs for kernel 2.6 developers
+ * BSD-style socket APIs for kernel 5.0 developers
  * 
  * @2007-2008, China
  * @song.xian-guang@hotmail.com (MSN Accounts)

--- a/sample/udp/ksocket_udp_srv_demo.c
+++ b/sample/udp/ksocket_udp_srv_demo.c
@@ -1,6 +1,6 @@
 /* 
  * ksocket project test sample - udp server
- * BSD-style socket APIs for kernel 2.6 developers
+ * BSD-style socket APIs for kernel 5.0 developers
  * 
  * @2007-2008, China
  * @song.xian-guang@hotmail.com (MSN Accounts)

--- a/src/ksocket.c
+++ b/src/ksocket.c
@@ -135,17 +135,17 @@ ksocket_t kaccept(ksocket_t socket, struct sockaddr *address, int *address_len)
 	new_sk->type = sk->type;
 	new_sk->ops = sk->ops;
 	
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 0, 0)
 	ret = kernel_accept(sk, &new_sk, 0);
 #else
-	ret = sk->ops->accept(sk, new_sk, 0 /*sk->file->f_flags*/);
+	ret = sk->ops->accept(sk, new_sk, 0);
 #endif
 	if (ret < 0)
 		goto error_kaccept;
 	
 	if (address)
 	{
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
 		ret = new_sk->ops->getname(new_sk, address, 2);
 #else
 		ret = new_sk->ops->getname(new_sk, address, address_len, 2);
@@ -201,7 +201,7 @@ ssize_t krecv(ksocket_t socket, void *buffer, size_t length, int flags)
 	old_fs = get_fs();
 	set_fs(KERNEL_DS);
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 0)
 	ret = sock_recvmsg(sk, &msg, flags);
 #else
 	ret = sock_recvmsg(sk, &msg, length, flags);
@@ -253,10 +253,10 @@ ssize_t ksend(ksocket_t socket, const void *buffer, size_t length, int flags)
 	old_fs = get_fs();
 	set_fs(KERNEL_DS);
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
-	len = sock_sendmsg(sk, &msg);//?
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+	len = sock_sendmsg(sk, &msg);
 #else
-	len = sock_sendmsg(sk, &msg, length);//?
+	len = sock_sendmsg(sk, &msg, length);
 #endif
 #ifndef KSOCKET_ADDR_SAFE
 	set_fs(old_fs);
@@ -327,7 +327,7 @@ ssize_t krecvfrom(ksocket_t socket, void * buffer, size_t length,
 	old_fs = get_fs();
 	set_fs(KERNEL_DS);
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 0)
 	len = sock_recvmsg(sk, &msg, flags);
 #else
 	len = sock_recvmsg(sk, &msg, length, flags);
@@ -383,7 +383,7 @@ ssize_t ksendto(ksocket_t socket, void *message, size_t length,
 	old_fs = get_fs();
 	set_fs(KERNEL_DS);
 #endif
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 	len = sock_sendmsg(sk, &msg);//?
 #else
 	len = sock_sendmsg(sk, &msg, length);//?
@@ -401,10 +401,10 @@ int kgetsockname(ksocket_t socket, struct sockaddr *address, int *address_len)
 	int ret;
 	
 	sk = (struct socket *)socket;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
-	ret = sk->ops->getname(sk, address, 0);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+	ret = kernel_getsockname(sk, address);
 #else
-	ret = sk->ops->getname(sk, address, address_len, 0);
+	ret = kernel_getsockname(sk, address, address_len);
 #endif
 	
 	return ret;
@@ -416,10 +416,10 @@ int kgetpeername(ksocket_t socket, struct sockaddr *address, int *address_len)
 	int ret;
 	
 	sk = (struct socket *)socket;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
-	ret = sk->ops->getname(sk, address, 1);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 17, 0)
+	ret = kernel_getpeername(sk, address);
 #else
-	ret = sk->ops->getname(sk, address, address_len, 1);
+	ret = kernel_getpeername(sk, address, address_len);
 #endif
 	
 	return ret;

--- a/src/ksocket.c
+++ b/src/ksocket.c
@@ -110,13 +110,8 @@ int klisten(ksocket_t socket, int backlog)
 
 int kconnect(ksocket_t socket, struct sockaddr *address, int address_len)
 {
-	struct socket *sk;
-	int ret;
-
-	sk = (struct socket *)socket;
-	ret = sk->ops->connect(sk, address, address_len, 0/*sk->file->f_flags*/);
-	
-	return ret;
+	struct socket *sk = (struct socket *)socket;
+	return kernel_connect(sk, address, address_len, O_RDWR/*sk->file->f_flags*/);
 }
 
 ksocket_t kaccept(ksocket_t socket, struct sockaddr *address, int *address_len)
@@ -141,7 +136,7 @@ ksocket_t kaccept(ksocket_t socket, struct sockaddr *address, int *address_len)
 	new_sk->ops = sk->ops;
 	
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
-	ret = sk->ops->accept(sk, new_sk, 0 , true);
+	ret = kernel_accept(sk, &new_sk, 0);
 #else
 	ret = sk->ops->accept(sk, new_sk, 0 /*sk->file->f_flags*/);
 #endif

--- a/src/ksocket.c
+++ b/src/ksocket.c
@@ -1,6 +1,6 @@
 /* 
  * ksocket project
- * BSD-style socket APIs for kernel 2.6 developers
+ * BSD-style socket APIs for kernel 5.0 developers
  * 
  * @2007-2008, China
  * @song.xian-guang@hotmail.com (MSN Accounts)
@@ -28,7 +28,7 @@
 
 #define KSOCKET_NAME	"ksocket"
 #define KSOCKET_VERSION	"0.0.2"
-#define KSOCKET_DESCPT	"BSD-style socket APIs for kernel 2.6 developers"
+#define KSOCKET_DESCPT	"BSD-style socket APIs for kernel 5.0 developers"
 #define KSOCKET_AUTHOR	"msn : song.xian-guang@hotmail.com\n"\
 						"blog: http://sxg.cublog.cn"
 #define KSOCKET_DATE	"2008-05-15"
@@ -111,7 +111,7 @@ int klisten(ksocket_t socket, int backlog)
 int kconnect(ksocket_t socket, struct sockaddr *address, int address_len)
 {
 	struct socket *sk = (struct socket *)socket;
-	return kernel_connect(sk, address, address_len, O_RDWR/*sk->file->f_flags*/);
+	return kernel_connect(sk, address, address_len, 0/*sk->file->f_flags*/);
 }
 
 ksocket_t kaccept(ksocket_t socket, struct sockaddr *address, int *address_len)

--- a/src/ksocket.h
+++ b/src/ksocket.h
@@ -1,6 +1,6 @@
 /* 
  * ksocket project
- * BSD-style socket APIs for kernel 2.6 developers
+ * BSD-style socket APIs for kernel 5.0 developers
  * 
  * @2007-2008, China
  * @song.xian-guang@hotmail.com (MSN Accounts)


### PR DESCRIPTION
Hey! I've been playing with ksocket and decided to update it to <= 5.4 kernels

- update to newer kernel_(connect/accept) API
- Fix a 5.4 crash when accept()
- Fix a couple more of minor issues
- Fix samples compilation by importing symvers

Here is a summary of it running using samples

    Tested on Linux ubuntu 5.4.0-66 x86-64
    
    [20651.173153] ksocket version 0.0.2
                   BSD-style socket APIs for kernel 5.0 developers
                   msn : song.xian-guang@hotmail.com
                   blog: http://sxg.cublog.cn
    [20666.927342] ksocket tcp srv init ok
    [20666.935602] sock_create sk= 0x00000000d1d8baad
    [20666.935606] sockfd_srv = 0x00000000d1d8baad
    [20666.935609] kbind ret = 0
    [20666.935611] family = 2, type = 1, protocol = 6
    [20675.506426] ksocket tcp cli init ok
    [20675.508137] sock_create sk= 0x000000005e2040e4
    [20675.508143] sockfd_cli = 0x000000005e2040e4
    [20675.508348] sockfd_cli = 0x000000005111d310
    [20675.508355] got connected from : 127.0.0.1 46064
    [20675.509777] connected to : quit 4444
    [20675.509833] got message : quit
    [20675.517874] got message : Hello, welcome to ksocket tcp srv service
    [20685.485744] ksocket tcp srv exit
    [20687.746083] ksocket tcp cli exit
    [20689.622516] ksocket exit
